### PR TITLE
Fix jpeg & svg

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,11 +1,24 @@
 'use strict';
 
-function getFileExtension(path) {
-  return path.split('.').pop();
+function getMime(path) {
+  var extension = path.split('.').pop();
+  if (['svg', 'jpg', 'jpeg', 'webp', 'gif', 'png'].indexOf(extension) === -1) {
+    throw new Error('Unsupported type of image');
+  }
+  
+  if (extension == 'svg') {
+    return 'image/svg+xml';
+  }
+  
+  if (extension == 'jpg') {
+    return 'image/jpeg';
+  }
+  
+  return 'image/' + extension;
 }
 
 module.exports = function base64ImageLoader(content) {
   this.cacheable && this.cacheable();
-  return `module.exports = "data:image/${getFileExtension(this.resourcePath)};base64,${content.toString('base64')}"`;
+  return `module.exports = "data:${getMime(this.resourcePath)};base64,${content.toString('base64')}"`;
 };
 module.exports.raw = true;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "base64-image-loader",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "base64 image loader for webpack",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Jpeg and svg files have mime types different to their file extensions. We should check it and substitute corresponding type.
