### PR TITLE
Extension matching is case insensitive

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const mimes = require('./mimes.json');
 
 function getMime(path) {
-  const extension = path.toLowerCase().split('.').pop();
+  const extension = path.split('.').pop().toLowerCase();
   const mime = mimes[extension];
   if (!mime) {
     throw new Error('Unsupported type of image of extension ' + extension + ': ' + path);

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 const mimes = require('./mimes.json');
 
 function getMime(path) {
-  const extension = path.split('.').pop();
+  const extension = path.toLowerCase().split('.').pop();
   const mime = mimes[extension];
   if (!mime) {
     throw new Error('Unsupported type of image of extension ' + extension + ': ' + path);

--- a/test/index.js
+++ b/test/index.js
@@ -52,4 +52,15 @@ describe('testImageBase64', () => {
 
     assert.include(result, testImageBase64);
   });
+
+  it('case insensitive extension matching', () => {
+    const testImage = fs.readFileSync('./test/1x1.png');
+    const testImageBase64 = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAIAAACQd1PeAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAAAMSURBVBhXY/j//z8ABf4C/qc1gYQAAAAASUVORK5CYII='; // eslint-disable-line max-len
+
+    const thisObj = { resourcePath: 'filename.pNG' };
+
+    const result = base64ImageLoader.call(thisObj, testImage);
+
+    assert.include(result, testImageBase64);
+  });
 });


### PR DESCRIPTION
Some developers may prefer `.PNG` instead of `.png`.